### PR TITLE
Added wrapper script with arguments to bypass Windows security policy

### DIFF
--- a/CheckAchievements.bat
+++ b/CheckAchievements.bat
@@ -1,0 +1,2 @@
+powershell.exe -ExecutionPolicy Bypass -File "CheckAchievements.ps1"
+pause

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ I decided to try and codify it, to make it easier.
 I wrote it in PowerShell so it should run on any Windows machine, just run:
 
 ``` cmd
-pwsh CheckAchievements.ps1
+pwsh -ExecutionPolicy Bypass -File "CheckAchievements.ps1"
+```
+
+Alternatively, you may run the `CheckAchievements.bat` batch file which calls the script with the appropriate arguments:
+
+``` cmd
+CheckAchievements.bat
 ```
 
 ## Output


### PR DESCRIPTION
On some Windows machines the security policy does not allow executing PowerShell scripts by default. An argument needs to be passed to PowerShell to tell it to make an exception and run the script.

- The readme has been updated to reflect this related to how it suggests to run the PowerShell script
- A wrapper Windows batch file has been added to make running the script with arguments more convenient
